### PR TITLE
Use CircleCI version 2.0 for all future build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,4 @@ jobs:
             - run: yarn test:server
             - run: yarn test:client --progress false
             - run: yarn e2e --progress false
-            - run: yarn ng build --prod
+            - run: yarn ng build --prod --progress false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ jobs:
         docker:
             - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
+                environment:
+                    - MYSQL_ALLOW_EMPTY_PASSWORD=true
+                    - MYSQL_HOST=127.0.0.1
+                    - MYSQL_ROOT_HOST=%
+                    - MYSQL_USER=root
+
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
             - run:
                 name: wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
+            - setup_remote_docker
             - run: mysql -u root -p < server/test/init.sql
             - run: yarn install
             - run: yarn test:server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,14 @@ jobs:
             - image: circleci/mysql:5.7-ram
         steps:
             - checkout
+            - run:
+                name: install dockerize
+                command: wget https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz && rm dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
+                environment:
+                    DOCKERIZE_VERSION: v0.6.0
+            - run:
+                name: wait for DB
+                command: dockerize -wait tcp://localhost:3306 -timeout 1m
             - run: mysql -u root -p < server/test/init.sql
             - run: yarn install
             - run: yarn test:server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: circleci/node:9-stretch-browsers
+        steps:
+            - checkout
+            - run: google-chrome-stable --version
+            - run: google-chrome --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,8 @@ jobs:
             - image: circleci/node:9-stretch-browsers
         steps:
             - checkout
-            - run: google-chrome-stable --version
-            - run: google-chrome --version
+            - run: yarn install
+            - run: yarn test:server
+            - run: yarn test:client --progress false
+            - run: yarn e2e --progress false
+            - run: yarn ng build --prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,6 @@ jobs:
         steps:
             - checkout
             - run:
-                name: install dockerize
-                command: wget https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz && rm dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
-                environment:
-                    DOCKERIZE_VERSION: v0.6.0
-            - run:
                 name: wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
             - run: mysql -u root -p < server/test/init.sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - run:
                 name: wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - run: mysql -u root < server/test/init.sql
+            - run: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - run: yarn install
             - run: yarn test:server
             - run: yarn test:client --progress false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,13 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/node:9-stretch-browsers
+            - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
         steps:
             - checkout
             - run:
                 name: wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - setup_remote_docker
             - run: mysql -u root -p < server/test/init.sql
             - run: yarn install
             - run: yarn test:server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
             - image: circleci/node:9-stretch-browsers
         steps:
             - checkout
+            - run: yarn config set registry https://registry.npmjs.org/
             - run: yarn install
             - run: yarn test:server
             - run: yarn test:client --progress false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ jobs:
     build:
         docker:
             - image: circleci/node:9-stretch-browsers
+            - image: circleci/mysql:5.7-ram
         steps:
             - checkout
-            - run: yarn config set registry https://registry.npmjs.org/
+            - run: mysql -u root -p < server/test/init.sql
             - run: yarn install
             - run: yarn test:server
             - run: yarn test:client --progress false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             - run:
                 name: wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - run: mysql -u root -p < server/test/init.sql
+            - run: mysql -u root < server/test/init.sql
             - run: yarn install
             - run: yarn test:server
             - run: yarn test:client --progress false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,11 @@ jobs:
         docker:
             - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
-                environment:
-                    - MYSQL_ALLOW_EMPTY_PASSWORD=true
-                    - MYSQL_HOST=127.0.0.1
-                    - MYSQL_ROOT_HOST=%
-                    - MYSQL_USER=root
-
+              environment:
+                  - MYSQL_ALLOW_EMPTY_PASSWORD=true
+                  - MYSQL_HOST=127.0.0.1
+                  - MYSQL_ROOT_HOST=%
+                  - MYSQL_USER=root
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,24 @@ jobs:
         steps:
             - checkout
             - run:
-                name: wait for DB
+                name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - run: mysql -u root -h 127.0.0.1 < server/test/init.sql
-            - run: yarn install
-            - run: yarn test:server
-            - run: yarn test:client --progress false
-            - run: yarn e2e --progress false
-            - run: yarn ng build --prod --progress false
+            - run: 
+                name: Initialize DB
+                command: mysql -u root -h 127.0.0.1 < server/test/init.sql
+            - run:
+                name: Install dependencies
+                command: yarn install
+            - run:
+                name: Server tests
+                command: yarn test:server
+            - run:
+                name: Client tests
+                command: yarn test:client --progress false
+            - run:
+                name: e2e tests
+                command: yarn e2e --progress false
+            - run:
+                name: Build client in production mode
+                command: yarn ng build --prod --progress false
+

--- a/README.md
+++ b/README.md
@@ -81,7 +81,18 @@ You can also run protractor and debug using `chrome://inspect` using `yarn e2e:d
 
 To prevent rebuilding the website every time the e2e tests are run (what `yarn e2e` does), use two terminal windows. Run `yarn dev` on the first and `yarn e2e:prepped` (or `yarn e2e:prepped:debug`) in the second whenever necessary.
 
+#### CircleCI
 
+Helium uses CircleCI for continuous integration. The Dockerfile for the container that runs the test job can be found [here](https://github.com/mattbdean/Helium/blob/circleci-test/server/test/Dockerfile). Once modified, build and push the image to DockerHub:
+
+```sh
+$ docker build -t mattbdean/helium-test server/test
+$ docker push mattbdean/helium-test
+```
+
+The next build will automatically use this new image.
+
+Config can be found at `.circleci/config.yml`.
 
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmattbdean%2FHelium.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmattbdean%2FHelium?ref=badge_large)

--- a/server/test/Dockerfile
+++ b/server/test/Dockerfile
@@ -1,0 +1,7 @@
+# This Dockerfile is for the image that runs jobs on CircleCI. It's not very
+# different other than the fact that we install mysql-client.
+
+FROM circleci/node:9-browsers
+
+# We need the mysql command available to us
+RUN sudo apt-get install mysql-client

--- a/server/test/init.sql
+++ b/server/test/init.sql
@@ -6,13 +6,13 @@
 SET GLOBAL sql_mode = 'STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 
 # Ensure the user exists by creating it
-GRANT ALL ON *.* TO 'user'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL ON *.* TO 'user'@'%' IDENTIFIED BY 'password';
 # Drop the newly-created user (the above query can be replaced by DROP USER
 # IF EXISTS) with MySQL 5.7
-DROP USER 'user'@'localhost';
+DROP USER 'user'@'%';
 # Create the user again to ensure that the user exists
-GRANT ALL ON helium.* TO 'user'@'localhost' IDENTIFIED BY 'password';
-GRANT ALL ON helium2.* TO 'user'@'localhost';
+GRANT ALL ON helium.* TO 'user'@'%' IDENTIFIED BY 'password';
+GRANT ALL ON helium2.* TO 'user'@'%';
 
 # Other DB for cross-schema testing
 DROP DATABASE IF EXISTS helium2;


### PR DESCRIPTION
Advantages:

 - Faster build time, average went from ~7s to ~5s
   - Chrome doesn't have to be installed manually for every build, it's included in the container
   - Don't have to manually download Node, we can choose the version to be included in the container
   - Cache saving/restoring was previously uncontrollable and ended up making each build less predictable and slowed the whole build down unnecessarily
 - New environment is quicker to start

Disadvantages:

 - Build logic is a tiny bit more complex because we use a custom Docker image for the container that runs the tests