### PR TITLE
Non-scalable docker image, fixes #46

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ restore_deps_cache: &restore_deps_cache
 jobs:
     cache-preinstalled:
         docker:
-            - image: node:8
+            # Prefer CircleCI images because they're preinstalled
+            - image: circleci/node:8
         steps:
             - checkout
             # Use cached dependencies if there are any
@@ -39,7 +40,7 @@ jobs:
                     - "coverage/client"
     test-server:
         docker:
-            - image: node:8
+            - image: circleci/node:8
             - image: circleci/mysql:5.7-ram
               environment:
                   - MYSQL_ALLOW_EMPTY_PASSWORD=true
@@ -72,16 +73,15 @@ jobs:
             - run:
                 name: Start MySQL via Docker
                 command: |
-                    docker run -d \
+                    docker run -d --name mysql \
                         -e "MYSQL_ALLOW_EMPTY_PASSWORD=true" \
                         -e "MYSQL_HOST=127.0.0.1" \
                         -e "MYSQL_ROOT_HOST=%" \
-                        -e "MYSQL_USER=root" \
                         mysql/mysql-server:5.7
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+            - run: docker run -d --name helium mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run:
                 name: Install the MySQL client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,47 +62,17 @@ jobs:
 #            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
 #            - run: yarn e2e:prepped
 #            - run: docker kill $(docker ps -q)
-    build-docker:
-        docker:
-            - image: mattbdean/helium-test:latest
+    test-e2e:
+        machine: true
         steps:
             - checkout
-            - restore_cache:
-                <<: *restore_deps_cache
-            - setup_remote_docker
+#            - setup_remote_docker
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run:
-                name: Save Docker image to cache
-                command: |
-                    mkdir -p docker-cache
-                    docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
-            - save_cache:
-                key: docker-cache-{{ .Revision }}
-                paths:
-                    - "docker-cache"
-
-    test-e2e:
-        docker:
-            - image: mattbdean/helium-test:latest
-            - image: circleci/mysql:5.7-ram
-              environment:
-                  - MYSQL_ALLOW_EMPTY_PASSWORD=true
-                  - MYSQL_HOST=127.0.0.1
-                  - MYSQL_ROOT_HOST=%
-                  - MYSQL_USER=root
-        steps:
-            - checkout
-            - restore_cache:
-                <<: *restore_deps_cache
-            - restore_cache:
-                keys:
-                    - docker-cache-{{ .Revision }}
-            - setup_remote_docker
-            - run: docker load -i docker-cache/built-image.tar
             - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
+            - run: mysql --version
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ restore_deps_cache: &restore_deps_cache
 jobs:
     cache-preinstalled:
         docker:
-            - image: mattbdean/helium-test:latest
+            - image: node:8
         steps:
             - checkout
             # Use cached dependencies if there are any
@@ -20,9 +20,26 @@ jobs:
                 key: deps-{{ checksum "yarn.lock" }}
                 paths:
                     - "node_modules"
-    test-integration:
+    test-client:
         docker:
-            - image: mattbdean/helium-test:latest
+            - image: circleci/node:8-browsers
+        steps:
+            - checkout
+            - restore_cache:
+                <<: *restore_deps_cache
+            - run:
+                name: Client tests
+                command: yarn test:client --progress false
+            - run:
+                name: Build client in production mode
+                command: yarn ng build --prod --progress false
+            - save_cache:
+                key: client-tests-{{ .BuildNum }}
+                paths:
+                    - "coverage/client"
+    test-server:
+        docker:
+            - image: node:8
             - image: circleci/mysql:5.7-ram
               environment:
                   - MYSQL_ALLOW_EMPTY_PASSWORD=true
@@ -31,42 +48,27 @@ jobs:
                   - MYSQL_USER=root
         steps:
             - checkout
+            - restore_cache:
+                <<: *restore_deps_cache
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
-            - restore_cache:
-                <<: *restore_deps_cache
             - run:
                 name: Server tests
                 command: yarn test:server
-            - run:
-                name: Client tests
-                command: yarn test:client --progress false
-#            - run:
-#                name: Upload code coverage
-#                command: yarn codecov --disable=gcov
-#            - run:
-#                name: Build client in production mode
-#                command: yarn ng build --prod --progress false
-#            - run:
-#                name: e2e tests
-#                command: yarn e2e --progress false
-#            - setup_remote_docker
-#            - run:
-#                name: Login to DockerHub
-#                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-#            - run: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-#            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
-#            - run: yarn e2e:prepped
-#            - run: docker kill $(docker ps -q)
+            - save_cache:
+                key: server-tests-{{ .BuildNum }}
+                paths:
+                    - "coverage/server"
     test-e2e:
         machine: true
         steps:
             - checkout
-#            - setup_remote_docker
+            - restore_cache:
+                <<: *restore_deps_cache
             - run:
                 name: Start MySQL via Docker
                 command: |
@@ -92,15 +94,49 @@ jobs:
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
+            - run: yarn e2e:prepped
+#            - run:
+#                name: Login to DockerHub
+#                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+#            - run: docker kill $(docker ps -q)
+    codecov:
+        docker:
+            - image: node:8
+        steps:
+            - checkout
+            - restore_cache:
+                <<: *restore_deps_cache
+            - restore_cache:
+                keys:
+                    - server-tests-{{ .BuildNum }}
+            - restore_cache:
+                keys:
+                    - client-tests-{{ .BuildNum }}
+
+            # Make sure things are being saved/restore properly
+            - run: du -h -d 1 coverage/client | sort -h
+            - run: du -h -d 1 coverage/server | sort -h
+#            - run:
+#                name: Upload code coverage
+#                command: yarn codecov --disable=gcov
+            - run: echo "TODO" && false
+
 
 workflows:
     version: 2
     build:
         jobs:
             - cache-preinstalled
-            - test-integration:
+            - test-client:
+                requires:
+                    - cache-preinstalled
+            - test-server:
                 requires:
                     - cache-preinstalled
             - test-e2e:
                 requires:
                     - cache-preinstalled
+            - codecov:
+                requires:
+                    - test-client
+                    - test-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,16 +106,14 @@ jobs:
                 name: Install MySQL client, Yarn, and Chrome
                 command: |
                     sudo apt-get install mysql-client yarn google-chrome-stable
-            - run: mysql --version
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - run: yarn e2e:prepped
-            - run:
-                name: Login to DockerHub
-                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-#            - run: docker push ...
-#            - run: docker kill $(docker ps -q)
+            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
+            - persist_to_workspace:
+                root: /tmp/workspace
+                path: image.tar
     codecov:
         docker:
             - image: circleci/node:8
@@ -129,6 +127,17 @@ jobs:
             - run:
                 name: Upload code coverage
                 command: yarn codecov --disable=gcov
+    deploy:
+        machine: true
+        steps:
+            - attach_workspace:
+                at: /tmp/workspace
+            - run: [ -f /tmp/workspace/image.tar ]
+            - run:
+                name: Login to DockerHub
+                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            - run: docker load -i /tmp/workspace/image.tar
+            - run: docker push mattbdean:latest-dev-${CIRCLE_BRANCH}
 
 
 workflows:
@@ -149,3 +158,7 @@ workflows:
                 requires:
                     - test-client
                     - test-server
+            - deploy:
+                requires:
+                    - test-e2e
+                    - codecov # by extension also requires test-client and test-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,19 @@ jobs:
             - checkout
 #            - setup_remote_docker
             - run:
+                name: Install MySQL 5.7
+                command: |
+                    export DEBIAN_FRONTEND=noninteractive
+                    export MYSQL_ROOT_PASSWORD=toor
+                    echo debconf mysql-server/root_password password $MYSQL_ROOT_PASSWORD | sudo debconf-set-selections
+                    echo debconf mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD | sudo debconf-set-selections
+                    echo mysql-apt-config mysql-apt-config/enable-repo select mysql-5.7-dmr | sudo debconf-set-selections
+                    wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
+                    sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
+                    sudo apt-get update -q
+                    sudo apt-get install mysql-server
+                    rm ./*.deb
+            - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
             - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,9 +110,9 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - run: yarn e2e:prepped
-            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
+            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o ~/image.tar
             - persist_to_workspace:
-                root: .
+                root: ~
                 path: image.tar
     codecov:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
                 name: Build client in production mode
                 command: yarn ng build --prod --progress false
             - save_cache:
-                key: client-tests-{{ .BuildNum }}
+                key: client-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
                 paths:
                     - "coverage/client"
     test-server:
@@ -64,7 +64,7 @@ jobs:
                 name: Server tests
                 command: yarn test:server
             - save_cache:
-                key: server-tests-{{ .BuildNum }}
+                key: server-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
                 paths:
                     - "coverage/server"
     test-e2e:
@@ -76,7 +76,7 @@ jobs:
             - run:
                 name: Start MySQL via Docker
                 command: |
-                    docker run -d --name mysql \
+                    docker run -d --name mysql -p 3306:3306 \
                         -e "MYSQL_ALLOW_EMPTY_PASSWORD=true" \
                         -e "MYSQL_HOST=127.0.0.1" \
                         -e "MYSQL_ROOT_HOST=%" \
@@ -111,10 +111,10 @@ jobs:
                 <<: *restore_deps_cache
             - restore_cache:
                 keys:
-                    - server-tests-{{ .BuildNum }}
+                    - server-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             - restore_cache:
                 keys:
-                    - client-tests-{{ .BuildNum }}
+                    - client-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
 
             # Make sure things are being saved/restore properly
             - run: du -h -d 1 coverage/client | sort -h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
     version: 2
     build:
         jobs:
-            - cache-deps
+            - cache-preinstalled
             - test-integration:
                 requires:
                     - cache-preinstalled

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
                         -e "MYSQL_HOST=127.0.0.1" \
                         -e "MYSQL_ROOT_HOST=%" \
                         -e "MYSQL_USER=root" \
-                        circleci/mysql:5.7-ram
+                        mysql/mysql-server:5.7
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
@@ -83,7 +83,10 @@ jobs:
             - run: docker ps
             - run:
                 name: Install the MySQL client
-                command: sudo apt-get install mysql-client
+                command: |
+                    DEBIAN_FRONTEND=noninteractive sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
+                    sudo apt-get update
+                    sudo apt-get install mysql-client
             - run: mysql --version
             - run:
                 name: Initialize DB

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             - persist_to_workspace:
                 root: .
                 paths:
-                    - "coverage"
+                    - "coverage/client/lcov.info"
     test-server:
         docker:
             - image: circleci/node:8
@@ -66,7 +66,7 @@ jobs:
             - persist_to_workspace:
                 root: .
                 paths:
-                    - "coverage"
+                    - "coverage/server/lcov.info"
     test-e2e:
         machine: true
         steps:
@@ -84,7 +84,7 @@ jobs:
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d --name helium mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+            - run: docker run -d --name helium -p 3000:3000 mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run:
                 name: Add required APT repositories
@@ -114,6 +114,7 @@ jobs:
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+#            - run: docker push ...
 #            - run: docker kill $(docker ps -q)
     codecov:
         docker:
@@ -125,12 +126,9 @@ jobs:
             - attach_workspace:
                 at: /tmp/workspace
             - run: cp -r /tmp/workspace/coverage ~/project
-            # Make sure things are being saved/restore properly
-            - run: du -h -d 2 coverage
-#            - run:
-#                name: Upload code coverage
-#                command: yarn codecov --disable=gcov
-            - run: echo "TODO" && false
+            - run:
+                name: Upload code coverage
+                command: yarn codecov --disable=gcov
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
-restore_deps_cache: &restore_deps_cache
+restore_repo_cache: &restore_repo_cache
     keys:
-        - deps-{{ .Revision }}
+        - preinstalled-{{ .Revision }}
 jobs:
-    cache-deps:
+    cache-preinstalled:
         docker:
             - image: mattbdean/helium-test:latest
         steps:
@@ -12,10 +12,10 @@ jobs:
                 name: Install dependencies
                 command: yarn install
             - save_cache:
-                key: deps-{{ .Revision }}
+                key: preinstalled-{{ .Revision }}
                 paths:
-                    - "node_modules"
-    test-integration:
+                    - "."
+    test-client:
         docker:
             - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
@@ -25,7 +25,6 @@ jobs:
                   - MYSQL_ROOT_HOST=%
                   - MYSQL_USER=root
         steps:
-            - checkout
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
@@ -33,7 +32,7 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - restore_cache:
-                <<: *restore_deps_cache
+                <<: *restore_repo_cache
             - run:
                 name: Server tests
                 command: yarn test:server
@@ -64,11 +63,11 @@ jobs:
             - checkout
             - setup_remote_docker
             - restore_cache:
-                <<: *restore_deps_cache
+                <<: *restore_repo_cache
             - run: |
-                docker build -t mattbdean/helium:latest-dev:${CIRCLE_BRANCH} .
+                docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
                 mkdir -p docker-cache
-                docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev:${CIRCLE_BRANCH}
+                docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - save_cache:
                 key: docker-cache-{{ .Revision }}
                 paths:
@@ -91,7 +90,7 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - restore_cache:
-                <<: *restore_deps_cache
+                <<: *restore_repo_cache
             - restore_cache:
                 -keys: docker-cache-{{ .Revision }}
             - run: docker load -i docker-cache/built-image.tar
@@ -105,10 +104,10 @@ workflows:
             - cache-deps
             - test-integration:
                 requires:
-                    - cache-deps
+                    - cache-preinstalled
             - build-docker:
                 requires:
-                    - cache-deps
+                    - cache-preinstalled
             - test-e2e:
                 requires:
                     - build-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,19 +20,27 @@ jobs:
             - run:
                 name: Install dependencies
                 command: yarn install
+#            - run:
+#                name: Server tests
+#                command: yarn test:server
+#            - run:
+#                name: Client tests
+#                command: yarn test:client --progress false
+#            - run:
+#                name: Upload code coverage
+#                command: yarn codecov --disable=gcov
+#            - run:
+#                name: e2e tests
+#                command: yarn e2e --progress false
+#            - run:
+#                name: Build client in production mode
+#                command: yarn ng build --prod --progress false
+            - setup_remote_docker
             - run:
-                name: Server tests
-                command: yarn test:server
-            - run:
-                name: Client tests
-                command: yarn test:client --progress false
-            - run:
-                name: Upload code coverage
-                command: yarn codecov --disable=gcov
-            - run:
-                name: e2e tests
-                command: yarn e2e --progress false
-            - run:
-                name: Build client in production mode
-                command: yarn ng build --prod --progress false
+                name: Login to DockerHub
+                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            - run: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
+            - run: docker run -d mattbdean/helium:latest-dev
+            - run: yarn e2e:prepped
+            - run: docker kill $(docker ps -q)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,20 +94,21 @@ jobs:
                   - MYSQL_USER=root
         steps:
             - checkout
+            - restore_cache:
+                <<: *restore_deps_cache
+            - restore_cache:
+                keys:
+                    - docker-cache-{{ .Revision }}
+            - setup_remote_docker
+            - run: docker load -i docker-cache/built-image.tar
+            - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d
+            - run: docker ps
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
-            - restore_cache:
-                <<: *restore_deps_cache
-            - restore_cache:
-                keys:
-                    - docker-cache-{{ .Revision }}
-            - run: docker load -i docker-cache/built-image.tar
-            - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d
-            - run: docker ps
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,21 @@
 version: 2
+restore_deps_cache: &restore_deps_cache
+    keys:
+        - deps-{{ .Revision }}
 jobs:
-    build:
+    cache-deps:
+        docker:
+            - image: mattbdean/helium-test:latest
+        steps:
+            - checkout
+            - run:
+                name: Install dependencies
+                command: yarn install
+            - save_cache:
+                key: deps-{{ .Revision }}
+                paths:
+                    - "node_modules"
+    test-integration:
         docker:
             - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
@@ -14,33 +29,86 @@ jobs:
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - run: 
+            - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
+            - restore_cache:
+                <<: *restore_deps_cache
             - run:
-                name: Install dependencies
-                command: yarn install
-#            - run:
-#                name: Server tests
-#                command: yarn test:server
-#            - run:
-#                name: Client tests
-#                command: yarn test:client --progress false
+                name: Server tests
+                command: yarn test:server
+            - run:
+                name: Client tests
+                command: yarn test:client --progress false
 #            - run:
 #                name: Upload code coverage
 #                command: yarn codecov --disable=gcov
 #            - run:
-#                name: e2e tests
-#                command: yarn e2e --progress false
-#            - run:
 #                name: Build client in production mode
 #                command: yarn ng build --prod --progress false
+#            - run:
+#                name: e2e tests
+#                command: yarn e2e --progress false
+#            - setup_remote_docker
+#            - run:
+#                name: Login to DockerHub
+#                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+#            - run: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
+#            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+#            - run: yarn e2e:prepped
+#            - run: docker kill $(docker ps -q)
+    build-docker:
+        docker:
+            - image: mattbdean/helium-test:latest
+        steps:
+            - checkout
             - setup_remote_docker
-            - run:
-                name: Login to DockerHub
-                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            - run: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
-            - run: yarn e2e:prepped
-            - run: docker kill $(docker ps -q)
+            - restore_cache:
+                <<: *restore_deps_cache
+            - run: |
+                docker build mattbdean/helium:latest-dev:${CIRCLE_BRANCH} .
+                mkdir -p docker-cache
+                docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev:${CIRCLE_BRANCH}
+            - save_cache:
+                key: docker-cache-{{ .Revision }}
+                paths:
+                    - "docker-cache"
 
+    test-e2e:
+        docker:
+            - image: mattbdean/helium-test:latest
+            - image: circleci/mysql:5.7-ram
+              environment:
+                  - MYSQL_ALLOW_EMPTY_PASSWORD=true
+                  - MYSQL_HOST=127.0.0.1
+                  - MYSQL_ROOT_HOST=%
+                  - MYSQL_USER=root
+        steps:
+            - run:
+                name: Wait for DB
+                command: dockerize -wait tcp://localhost:3306 -timeout 1m
+            - run:
+                name: Initialize DB
+                command: mysql -u root -h 127.0.0.1 < server/test/init.sql
+            - restore_cache:
+                <<: *restore_deps_cache
+            - restore_cache:
+                -keys: docker-cache-{{ .Revision }}
+            - run: docker load -i docker-cache/built-image.tar
+            - run: docker run mattbdean/helium:latest-dev:${CIRCLE_BRANCH} -d
+            - run: docker ps
+
+workflows:
+    version: 2
+    build:
+        jobs:
+            - cache-deps
+            - test-integration:
+                requires:
+                    - cache-deps
+            - build-docker:
+                requires:
+                    - cache-deps
+            - test-e2e:
+                requires:
+                    - build-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
             - restore_cache:
                 <<: *restore_deps_cache
             - restore_cache:
-                - keys:
+                keys:
                     - docker-cache-{{ .Revision }}
             - run: docker load -i docker-cache/built-image.tar
             - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
     deploy:
         machine: true
         steps:
+            - checkout
             - attach_workspace:
                 at: /tmp/workspace
             - run: docker load -i /tmp/workspace/image.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
             - run:
                 name: Install the MySQL client
                 command: |
+                    wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
                     DEBIAN_FRONTEND=noninteractive sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
                     sudo apt-get update
                     sudo apt-get install mysql-client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,9 @@ jobs:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
-            - run: yarn gulp common:build
+            - run:
+                name: Build common files
+                command: yarn gulp common:build
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
@@ -146,12 +148,14 @@ jobs:
             - checkout
             - attach_workspace:
                 at: /tmp/workspace
-            - run: docker load -i /tmp/workspace/image.tar
+            - run:
+                name: Load Docker image from workspace
+                command: docker load -i /tmp/workspace/image.tar
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             - run:
-                name: Push to DockerHug
+                name: Push to DockerHub
                 command: docker push mattbdean/helium:$(.circleci/docker-tag.sh)
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             - restore_cache:
                 <<: *restore_deps_cache
             - run: |
-                docker build mattbdean/helium:latest-dev:${CIRCLE_BRANCH} .
+                docker build -t mattbdean/helium:latest-dev:${CIRCLE_BRANCH} .
                 mkdir -p docker-cache
                 docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev:${CIRCLE_BRANCH}
             - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
-            - run: yarn gulp common:build
+            - run:
+                name: Build common files
+                command: yarn gulp common:build
             - run:
                 name: Client tests
                 command: yarn test:client --progress false
@@ -56,7 +58,9 @@ jobs:
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
-            - run: sudo apt-get install mysql-client
+            - run:
+                name: Install MySQL client
+                command: sudo apt-get install mysql-client
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
@@ -129,10 +133,13 @@ jobs:
                 <<: *restore_deps_cache
             - attach_workspace:
                 at: /tmp/workspace
-            - run: cp -r /tmp/workspace/coverage ~/project
+            - run:
+                name: Copy coverage data from client and server tests
+                command: cp -r /tmp/workspace/coverage ~/project
             - run:
                 name: Upload code coverage
                 command: yarn codecov --disable=gcov
+
     deploy:
         machine: true
         steps:
@@ -143,8 +150,9 @@ jobs:
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            - run: docker push mattbdean/helium:$(.circleci/docker-tag.sh)
-
+            - run:
+                name: Push to DockerHug
+                command: docker push mattbdean/helium:$(.circleci/docker-tag.sh)
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ restore_deps_cache: &restore_deps_cache
         - deps-{{ checksum "yarn.lock" }}
 jobs:
     cache-preinstalled:
-        docker:
-            - image: mattbdean/helium-test:latest
+        machine: true
         steps:
             - checkout
             # Use cached dependencies if there are any

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,26 @@
 version: 2
-restore_repo_cache: &restore_repo_cache
+restore_deps_cache: &restore_deps_cache
     keys:
-        - preinstalled-{{ .Revision }}
+        - deps-{{ checksum "yarn.lock" }}
 jobs:
     cache-preinstalled:
         docker:
             - image: mattbdean/helium-test:latest
         steps:
             - checkout
+            # Use cached dependencies if there are any
+            - restore_cache:
+                <<: *restore_deps_cache
+            # If there was no cache install everything
             - run:
                 name: Install dependencies
                 command: yarn install
+            # Save the cache here
             - save_cache:
-                key: preinstalled-{{ .Revision }}
+                key: deps-{{ checksum "yarn.lock" }}
                 paths:
-                    - "."
-    test-client:
+                    - "node_modules"
+    test-integration:
         docker:
             - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
@@ -25,6 +30,7 @@ jobs:
                   - MYSQL_ROOT_HOST=%
                   - MYSQL_USER=root
         steps:
+            - checkout
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
@@ -32,7 +38,7 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - restore_cache:
-                <<: *restore_repo_cache
+                <<: *restore_deps_cache
             - run:
                 name: Server tests
                 command: yarn test:server
@@ -61,9 +67,9 @@ jobs:
             - image: mattbdean/helium-test:latest
         steps:
             - checkout
-            - setup_remote_docker
             - restore_cache:
-                <<: *restore_repo_cache
+                <<: *restore_deps_cache
+            - setup_remote_docker
             - run: |
                 docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
                 mkdir -p docker-cache
@@ -83,6 +89,7 @@ jobs:
                   - MYSQL_ROOT_HOST=%
                   - MYSQL_USER=root
         steps:
+            - checkout
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
@@ -90,7 +97,7 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - restore_cache:
-                <<: *restore_repo_cache
+                <<: *restore_deps_cache
             - restore_cache:
                 -keys: docker-cache-{{ .Revision }}
             - run: docker load -i docker-cache/built-image.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,14 @@ jobs:
             - restore_cache:
                 <<: *restore_deps_cache
             - setup_remote_docker
-            - run: |
-                docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-                mkdir -p docker-cache
-                docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+            - run:
+                name: Build Docker image
+                command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
+            - run:
+                name: Save Docker image to cache
+                command: |
+                    mkdir -p docker-cache
+                    docker save -o docker-cache/built-image.tar mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - save_cache:
                 key: docker-cache-{{ .Revision }}
                 paths:
@@ -99,7 +103,8 @@ jobs:
             - restore_cache:
                 <<: *restore_deps_cache
             - restore_cache:
-                -keys: docker-cache-{{ .Revision }}
+                - keys:
+                    - docker-cache-{{ .Revision }}
             - run: docker load -i docker-cache/built-image.tar
             - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d
             - run: docker ps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d --name helium -p 3000:3000 mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+            - run: docker run -d --name helium --net=host -p 3000:3000 mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run:
                 name: Add required APT repositories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,9 @@ jobs:
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
             - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
+            - run:
+                name: Install the MySQL client
+                command: sudo apt-get install mysql-client
             - run: mysql --version
             - run:
                 name: Initialize DB

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
                     - "coverage/client"
     test-server:
         docker:
-            - image: mattbdean/helium-test:latest
+            - image: circleci/node:8
             - image: circleci/mysql:5.7-ram
               environment:
                   - MYSQL_ALLOW_EMPTY_PASSWORD=true
@@ -56,6 +56,7 @@ jobs:
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
+            - run: sudo apt-get install mysql-client
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,14 @@ jobs:
             - checkout
 #            - setup_remote_docker
             - run:
-                name: Install MySQL 5.7
+                name: Start MySQL via Docker
                 command: |
-                    export DEBIAN_FRONTEND=noninteractive
-                    echo mysql-apt-config mysql-apt-config/enable-repo select mysql-5.7-dmr | sudo debconf-set-selections
-                    wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
-                    sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
-                    sudo apt-get update -q
-                    sudo -E apt-get install -q -y mysql-server
-                    rm ./*.deb
+                    docker run -d \
+                        -e "MYSQL_ALLOW_EMPTY_PASSWORD=true" \
+                        -e "MYSQL_HOST=127.0.0.1" \
+                        -e "MYSQL_ROOT_HOST=%" \
+                        -e "MYSQL_USER=root" \
+                        circleci/mysql:5.7-ram
             - run:
                 name: Build Docker image
                 command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,14 +71,11 @@ jobs:
                 name: Install MySQL 5.7
                 command: |
                     export DEBIAN_FRONTEND=noninteractive
-                    export MYSQL_ROOT_PASSWORD=toor
-                    echo debconf mysql-server/root_password password $MYSQL_ROOT_PASSWORD | sudo debconf-set-selections
-                    echo debconf mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD | sudo debconf-set-selections
                     echo mysql-apt-config mysql-apt-config/enable-repo select mysql-5.7-dmr | sudo debconf-set-selections
                     wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
                     sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
                     sudo apt-get update -q
-                    sudo apt-get install mysql-server
+                    sudo -E apt-get install -q -y mysql-server
                     rm ./*.deb
             - run:
                 name: Build Docker image
@@ -86,9 +83,6 @@ jobs:
             - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run: mysql --version
-            - run:
-                name: Wait for DB
-                command: dockerize -wait tcp://localhost:3306 -timeout 1m
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,15 +93,19 @@ jobs:
                     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
                     echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
+                    # Chrome
+                    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+                    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
+
                     # MySQL
                     wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
                     DEBIAN_FRONTEND=noninteractive sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
 
                     sudo apt-get update
             - run:
-                name: Install MySQL client and Yarn
+                name: Install MySQL client, Yarn, and Chrome
                 command: |
-                    sudo apt-get install mysql-client yarn
+                    sudo apt-get install mysql-client yarn google-chrome-stable
             - run: mysql --version
             - run:
                 name: Initialize DB
@@ -113,14 +117,14 @@ jobs:
 #            - run: docker kill $(docker ps -q)
     codecov:
         docker:
-            - image: node:8
+            - image: circleci/node:8
         steps:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
             - attach_workspace:
                 at: /tmp/workspace
-            - run: cp -r /tmp/workspace/coverage ${CIRCLE_WORKING_DIRECTORY}
+            - run: cp -r /tmp/workspace/coverage ~/project
             # Make sure things are being saved/restore properly
             - run: du -h -d 2 coverage
 #            - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,10 @@ jobs:
         steps:
             - attach_workspace:
                 at: /tmp/workspace
-            - run: [ -f /tmp/workspace/image.tar ]
+            - run: docker load -i /tmp/workspace/image.tar
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            - run: docker load -i /tmp/workspace/image.tar
             - run: docker push mattbdean:latest-dev-${CIRCLE_BRANCH}
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
             - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
             - persist_to_workspace:
                 root: .
-                path: image.tar
+                paths:
+                    - "image.tar"
     codecov:
         docker:
             - image: circleci/node:8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 restore_deps_cache: &restore_deps_cache
     keys:
-        - deps-{{ checksum "yarn.lock" }}
+        - deps-node8-{{ checksum "yarn.lock" }}
 jobs:
     cache-preinstalled:
         docker:
@@ -18,7 +18,7 @@ jobs:
                 command: yarn install
             # Save the cache here
             - save_cache:
-                key: deps-{{ checksum "yarn.lock" }}
+                key: deps-node8-checksum "yarn.lock" }}
                 paths:
                     - "node_modules"
     test-client:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                 command: yarn install
             # Save the cache here
             - save_cache:
-                key: deps-node8-checksum "yarn.lock" }}
+                key: deps-node8-{{ checksum "yarn.lock" }}
                 paths:
                     - "node_modules"
     test-client:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            - run: docker push mattbdean:latest-dev-${CIRCLE_BRANCH}
+            - run: docker push mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
             - run:
                 name: Build client in production mode
                 command: yarn ng build --prod --progress false
-            - save_cache:
-                key: client-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            - persist_to_workspace:
+                root: .
                 paths:
-                    - "coverage/client"
+                    - "coverage"
     test-server:
         docker:
             - image: circleci/node:8
@@ -63,10 +63,10 @@ jobs:
             - run:
                 name: Server tests
                 command: yarn test:server
-            - save_cache:
-                key: server-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            - persist_to_workspace:
+                root: .
                 paths:
-                    - "coverage/server"
+                    - "coverage"
     test-e2e:
         machine: true
         steps:
@@ -118,16 +118,11 @@ jobs:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
-            - restore_cache:
-                keys:
-                    - server-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-            - restore_cache:
-                keys:
-                    - client-tests-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-
+            - attach_workspace:
+                at: /tmp/workspace
+            - run: cp -r /tmp/workspace/coverage ${CIRCLE_WORKING_DIRECTORY}
             # Make sure things are being saved/restore properly
-            - run: du -h -d 1 coverage/client | sort -h
-            - run: du -h -d 1 coverage/server | sort -h
+            - run: du -h -d 2 coverage
 #            - run:
 #                name: Upload code coverage
 #                command: yarn codecov --disable=gcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             - run: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d mattbdean/helium:latest-dev
+            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: yarn e2e:prepped
             - run: docker kill $(docker ps -q)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ restore_deps_cache: &restore_deps_cache
         - deps-{{ checksum "yarn.lock" }}
 jobs:
     cache-preinstalled:
-        machine: true
+        docker:
+            - image: mattbdean/helium-test:latest
         steps:
             - checkout
             # Use cached dependencies if there are any

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,21 @@ jobs:
             - run: docker run -d --name helium mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run:
-                name: Install the MySQL client
+                name: Add required APT repositories
                 command: |
+                    # Yarn
+                    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+                    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+                    # MySQL
                     wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
                     DEBIAN_FRONTEND=noninteractive sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb
+
                     sudo apt-get update
-                    sudo apt-get install mysql-client
+            - run:
+                name: Install MySQL client and Yarn
+                command: |
+                    sudo apt-get install mysql-client yarn
             - run: mysql --version
             - run:
                 name: Initialize DB

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,11 @@ jobs:
                         -e "MYSQL_ROOT_HOST=%" \
                         mysql/mysql-server:5.7
             - run:
-                name: Build Docker image
-                command: docker build -t mattbdean/helium:latest-dev-${CIRCLE_BRANCH} .
-            - run: docker run -d --name helium --net=host -p 3000:3000 mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
-            - run: docker ps
+                name: Build Helium Docker image
+                command: docker build -t mattbdean/helium:$(.circleci/docker-tag.sh) .
+            - run:
+                name: Start Helium via Docker
+                command: docker run -d --name helium --net=host -p 3000:3000 mattbdean/helium:$(.circleci/docker-tag.sh)
             - run:
                 name: Add required APT repositories
                 command: |
@@ -109,8 +110,12 @@ jobs:
             - run:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
-            - run: yarn e2e:prepped
-            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
+            - run:
+                name: Run e2e tests
+                command: yarn e2e:prepped
+            - run:
+                name: Save Helium docker image to workspace
+                command: docker save mattbdean/helium:$(.circleci/docker-tag.sh) -o image.tar
             - persist_to_workspace:
                 root: .
                 paths:
@@ -137,7 +142,7 @@ jobs:
             - run:
                 name: Login to DockerHub
                 command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            - run: docker push mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
+            - run: docker push mattbdean/helium:$(.circleci/docker-tag.sh)
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             - restore_cache:
                 -keys: docker-cache-{{ .Revision }}
             - run: docker load -i docker-cache/built-image.tar
-            - run: docker run mattbdean/helium:latest-dev:${CIRCLE_BRANCH} -d
+            - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d
             - run: docker ps
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,9 +110,9 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - run: yarn e2e:prepped
-            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o ~/image.tar
+            - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
             - persist_to_workspace:
-                root: ~
+                root: .
                 path: image.tar
     codecov:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
+            - run: yarn gulp common:build
             - run:
                 name: Client tests
                 command: yarn test:client --progress false
@@ -40,7 +41,7 @@ jobs:
                     - "coverage/client"
     test-server:
         docker:
-            - image: circleci/node:8
+            - image: mattbdean/helium-test:latest
             - image: circleci/mysql:5.7-ram
               environment:
                   - MYSQL_ALLOW_EMPTY_PASSWORD=true
@@ -51,6 +52,7 @@ jobs:
             - checkout
             - restore_cache:
                 <<: *restore_deps_cache
+            - run: yarn gulp common:build
             - run:
                 name: Wait for DB
                 command: dockerize -wait tcp://localhost:3306 -timeout 1m
@@ -95,9 +97,9 @@ jobs:
                 name: Initialize DB
                 command: mysql -u root -h 127.0.0.1 < server/test/init.sql
             - run: yarn e2e:prepped
-#            - run:
-#                name: Login to DockerHub
-#                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            - run:
+                name: Login to DockerHub
+                command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
 #            - run: docker kill $(docker ps -q)
     codecov:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
             - run: yarn e2e:prepped
             - run: docker save mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -o image.tar
             - persist_to_workspace:
-                root: /tmp/workspace
+                root: .
                 path: image.tar
     codecov:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,6 @@ workflows:
             - test-integration:
                 requires:
                     - cache-preinstalled
-            - build-docker:
-                requires:
-                    - cache-preinstalled
             - test-e2e:
                 requires:
-                    - build-docker
+                    - cache-preinstalled

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
                     - docker-cache-{{ .Revision }}
             - setup_remote_docker
             - run: docker load -i docker-cache/built-image.tar
-            - run: docker run mattbdean/helium:latest-dev-${CIRCLE_BRANCH} -d
+            - run: docker run -d mattbdean/helium:latest-dev-${CIRCLE_BRANCH}
             - run: docker ps
             - run:
                 name: Wait for DB

--- a/.circleci/docker-tag.sh
+++ b/.circleci/docker-tag.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z ${CIRCLE_BRANCH} ]; then
+    echo "CIRCLE_BRANCH not set" 1>&2
+    exit 1
+fi
+
+if [ ${CIRCLE_BRANCH} == "master" ]; then
+    echo "latest-dev"
+else
+    echo "latest-dev-${CIRCLE_BRANCH}"
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/src/app
 
 # Get our dependencies ready
 COPY package.json yarn.lock .snyk ./
-COPY node_modules ./
 RUN yarn install
 
 # Add all the necessary build-related files

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 
 # Get our dependencies ready
 COPY package.json yarn.lock .snyk ./
+COPY node_modules ./
 RUN yarn install
 
 # Add all the necessary build-related files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Node 8+ should work
+FROM node:8
+
+WORKDIR /usr/src/app
+
+# Get our dependencies ready
+COPY package.json yarn.lock .snyk ./
+RUN yarn install
+
+# Add all the necessary build-related files
+COPY .angular-cli.json .babelrc Gulpfile.ts tsconfig.json ./
+
+# Add all sources
+COPY common ./common
+COPY client ./client
+COPY server ./server
+
+# Build in dev mode
+RUN yarn build
+
+# Helium binds to port 3000 by default
+EXPOSE 3000
+
+# All compiled files are located in dist/
+CMD node dist

--- a/server/test/Dockerfile
+++ b/server/test/Dockerfile
@@ -1,0 +1,7 @@
+# This Dockerfile is for the image that runs jobs on CircleCI. It's not very
+# different other than the fact that we install mysql-client.
+
+FROM circleci/node:9-browsers
+
+# We need the mysql command available to us
+RUN sudo apt-get install mysql-client

--- a/server/test/Dockerfile
+++ b/server/test/Dockerfile
@@ -1,7 +1,0 @@
-# This Dockerfile is for the image that runs jobs on CircleCI. It's not very
-# different other than the fact that we install mysql-client.
-
-FROM circleci/node:9-browsers
-
-# We need the mysql command available to us
-RUN sudo apt-get install mysql-client


### PR DESCRIPTION
We now take advantage of CircleCI's workflows to execute server, client, and e2e tests in parallel. Client and server tests are conducted exactly the same as before, but e2e tests are done against that commit's Docker image. If all tests pass, that image is uploaded to Helium's new [Docker Hub repo](https://hub.docker.com/r/mattbdean/helium/). Here's what the workflow looks like now:

![new workflow](https://i.imgur.com/xTAqoEu.png)

The newest Docker image that passed CI is located at `mattbdean/helium:latest-dev`. For branches other than master, use `mattbdean/helium:latest-dev-{branch}`.

```sh
$ docker run -d -p --name helium 3000:3000 mattbdean/helium:latest-dev
$ curl localhost:3000
$ docker kill helium
```

See also [#59](https://github.com/mattbdean/Helium/issues/59).